### PR TITLE
Add proper OG tags. Fix #72

### DIFF
--- a/ckanext-offgridtheme/ckanext/offgridtheme/templates/base.html
+++ b/ckanext-offgridtheme/ckanext/offgridtheme/templates/base.html
@@ -3,9 +3,14 @@
 {% block meta %}
   {{ super() }}
 
-  <meta name="description" content="energydata.info is an innovation from the World Bank Group providing open data and open source analytics for a sustainable energy future." />
-  <meta name="twitter:image:src" content="https://energydata.info/images/meta/default-meta-image.png" />
+  <meta name="description" content="{{ g.site_description }}" />
+
+  <meta property="og:title" content="{{ g.site_title }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="{{ h.full_current_url() }}" />
+  <meta property="og:description" content="{{ g.site_description }}" />
   <meta property="og:image" content="https://energydata.info/images/meta/default-meta-image.png" />
+  <meta name="twitter:image:src" content="https://energydata.info/images/meta/default-meta-image.png" />
 
   <link rel="apple-touch-icon" href="/images/meta/apple-touch-icon.png" />
   <link rel="apple-touch-icon" sizes="57x57" href="/images/meta/apple-touch-icon-57x57.png" />

--- a/development.ini.sample
+++ b/development.ini.sample
@@ -56,7 +56,7 @@ ckan.datastore.default_fts_index_method = gist
 
 ## Site Settings
 
-ckan.site_url = 192.169.101.99
+ckan.site_url = https://energydata.info
 #ckan.use_pylons_response_cleanup_middleware = true
 
 ## Authorization Settings
@@ -114,9 +114,9 @@ ckanext.mvt.mapbox.style = cir6ljf470006bsmehhstmxeh cioenuwii001maznontujohu8
 ckanext.mvt.mapbox.style_label = Light Colored
 
 ## Front-End Settings
-ckan.site_title = Energy Maps
+ckan.site_title = Energy Data
 ckan.site_logo =
-ckan.site_description =
+ckan.site_description = Open data and analytics for a sustainable energy future. Energy Data is an innovation of the World Bank Group.
 ckan.favicon = /images/meta/favicon.ico
 ckan.gravatar_default = identicon
 ckan.preview.direct = png jpg gif


### PR DESCRIPTION
This adds proper OG tags to the header and should fix the issues in #72.

When deploying, the following needs to be updated in the config `.ini`:

- `ckan.site_url = https://energydata.info`
- `ckan.site_title = Energy Data`
- `ckan.site_description = Open data and analytics for a sustainable energy future. Energy Data is an innovation of the World Bank Group.`