### PR TITLE
Load custom set of licenses. Fix #101

### DIFF
--- a/development.ini.sample
+++ b/development.ini.sample
@@ -131,7 +131,7 @@ ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain a
 #ckan.recaptcha.version = 1
 #ckan.recaptcha.publickey =
 #ckan.recaptcha.privatekey =
-#licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
+licenses_group_url = https://raw.githubusercontent.com/energy-data/energydata-licenses/master/licenses.json
 # ckan.template_footer_end =
 
 ## harvester settings


### PR DESCRIPTION
This loads a custom list of licenses from https://github.com/energy-data/energydata-licenses